### PR TITLE
Add scripted OpenPI fine-tune wrappers

### DIFF
--- a/scripts/openpi/README.md
+++ b/scripts/openpi/README.md
@@ -1,0 +1,43 @@
+# Scripted OpenPI LIBERO Fine-Tune Example
+
+This directory contains thin wrappers around the documented OpenPI `pi05_libero`
+fine-tuning flow.
+
+JAX entrypoint:
+
+```bash
+scripts/openpi/run_pi05_libero_finetune_example.sh --exp-name my_run
+```
+
+Default behavior:
+
+- reuses `openpi/assets/pi05_libero/physical-intelligence/libero/norm_stats.json` if it already exists
+- runs a bounded training example with `--num-train-steps 1`
+- writes logs and manifests under `tasks/openpi-scripted-libero-finetune-example/runs/<run-id>/`
+- writes checkpoints under `/mnt/local_storage/experiments/openpi_checkpoints/pi05_libero/<exp-name>/`
+
+To force a fresh bounded norm-stats pass before training:
+
+```bash
+scripts/openpi/run_pi05_libero_finetune_example.sh \
+  --exp-name my_run \
+  --refresh-norm-stats \
+  --max-frames 256
+```
+
+The script sets cache-related environment variables to `/mnt/local_storage` by
+default so repeated runs reuse local artifacts.
+
+PyTorch entrypoint:
+
+```bash
+scripts/openpi/run_pi05_libero_finetune_example_pytorch.sh --exp-name my_run
+```
+
+Default PyTorch behavior:
+
+- ensures the local `.venv` has OpenPI's patched `transformers` files without reusing hardlinked cache files
+- converts the cached JAX `pi05_base` checkpoint to a PyTorch checkpoint if needed
+- runs a bounded `scripts/train_pytorch.py pi05_libero` example with `--batch-size 4 --num-train-steps 1`
+- writes logs and manifests under `tasks/openpi-scripted-libero-finetune-example-pytorch/<run-id>/`
+- writes checkpoints under `/mnt/local_storage/experiments/openpi_pytorch_checkpoints/pi05_libero/<exp-name>/`

--- a/scripts/openpi/run_pi05_libero_finetune_example.sh
+++ b/scripts/openpi/run_pi05_libero_finetune_example.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run_pi05_libero_finetune_example.sh [options]
+
+Runs a bounded OpenPI LIBERO fine-tuning example for the documented `pi05_libero`
+config and writes logs under `tasks/openpi-scripted-libero-finetune-example/`.
+
+Options:
+  --exp-name <name>             Training experiment name.
+  --run-id <id>                 Artifact run id. Defaults to --exp-name.
+  --max-frames <int>            Max frames for bounded norm-stats refresh. Default: 256
+  --num-train-steps <int>       Number of training steps to run. Default: 1
+  --save-interval <int>         Checkpoint save interval. Default: 1
+  --log-interval <int>          Train log interval. Default: 1
+  --checkpoint-base-dir <path>  Checkpoint base directory.
+                                Default: /mnt/local_storage/experiments/openpi_checkpoints
+  --artifacts-root <path>       Root directory for logs and manifests.
+                                Default: test_openpi/tasks/openpi-scripted-libero-finetune-example/runs
+  --refresh-norm-stats          Recompute norm stats even if cached stats already exist.
+  --allow-overwrite             Reuse an existing run directory.
+  --dry-run                     Print the resolved plan and exit.
+  --help                        Show this help.
+USAGE
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_OPENPI_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OPENPI_DIR="$TEST_OPENPI_ROOT/openpi"
+CONFIG_NAME="pi05_libero"
+DEFAULT_EXP_NAME="pi05_libero_scripted_$(date -u +%Y%m%dT%H%M%SZ)"
+EXP_NAME="$DEFAULT_EXP_NAME"
+RUN_ID=""
+MAX_FRAMES="256"
+NUM_TRAIN_STEPS="1"
+SAVE_INTERVAL="1"
+LOG_INTERVAL="1"
+CHECKPOINT_BASE_DIR="/mnt/local_storage/experiments/openpi_checkpoints"
+ARTIFACTS_ROOT="$TEST_OPENPI_ROOT/tasks/openpi-scripted-libero-finetune-example/runs"
+REFRESH_NORM_STATS=0
+ALLOW_OVERWRITE=0
+DRY_RUN=0
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --exp-name)
+      EXP_NAME="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --max-frames)
+      MAX_FRAMES="${2:-}"
+      shift 2
+      ;;
+    --num-train-steps)
+      NUM_TRAIN_STEPS="${2:-}"
+      shift 2
+      ;;
+    --save-interval)
+      SAVE_INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --log-interval)
+      LOG_INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --checkpoint-base-dir)
+      CHECKPOINT_BASE_DIR="${2:-}"
+      shift 2
+      ;;
+    --artifacts-root)
+      ARTIFACTS_ROOT="${2:-}"
+      shift 2
+      ;;
+    --refresh-norm-stats)
+      REFRESH_NORM_STATS=1
+      shift
+      ;;
+    --allow-overwrite)
+      ALLOW_OVERWRITE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$EXP_NAME"
+fi
+
+if [[ ! -d "$OPENPI_DIR" ]]; then
+  echo "OpenPI checkout not found at: $OPENPI_DIR" >&2
+  exit 1
+fi
+
+command -v uv >/dev/null || {
+  echo "uv is required but not installed" >&2
+  exit 1
+}
+
+if ! [[ "$MAX_FRAMES" =~ ^[0-9]+$ && "$NUM_TRAIN_STEPS" =~ ^[0-9]+$ && "$SAVE_INTERVAL" =~ ^[0-9]+$ && "$LOG_INTERVAL" =~ ^[0-9]+$ ]]; then
+  echo "Numeric arguments must be non-negative integers" >&2
+  exit 2
+fi
+
+if (( MAX_FRAMES < 256 )); then
+  echo "--max-frames must be at least 256 for the pi05_libero batch size" >&2
+  exit 2
+fi
+
+if (( NUM_TRAIN_STEPS < 1 )); then
+  echo "--num-train-steps must be at least 1" >&2
+  exit 2
+fi
+
+rg -n 'name=\"pi05_libero\"' "$OPENPI_DIR/src/openpi/training/config.py" >/dev/null || {
+  echo "pi05_libero config not found in $OPENPI_DIR/src/openpi/training/config.py" >&2
+  exit 1
+}
+
+RUN_DIR="$ARTIFACTS_ROOT/$RUN_ID"
+COMPUTE_LOG="$RUN_DIR/compute_norm_stats.log"
+TRAIN_LOG="$RUN_DIR/train.log"
+MANIFEST_JSON="$RUN_DIR/run_manifest.json"
+RESULT_JSON="$RUN_DIR/result.json"
+NORM_STATS_FILE="$OPENPI_DIR/assets/pi05_libero/physical-intelligence/libero/norm_stats.json"
+CHECKPOINT_RUN_DIR="$CHECKPOINT_BASE_DIR/$CONFIG_NAME/$EXP_NAME"
+
+if [[ -e "$RUN_DIR" && "$ALLOW_OVERWRITE" -ne 1 ]]; then
+  echo "Run directory already exists: $RUN_DIR (use --allow-overwrite to reuse it)" >&2
+  exit 2
+fi
+
+mkdir -p "$RUN_DIR" "$CHECKPOINT_BASE_DIR"
+
+HF_HOME_VALUE="${OPENPI_HF_HOME:-/mnt/local_storage/huggingface}"
+HF_HUB_CACHE_VALUE="${OPENPI_HF_HUB_CACHE:-$HF_HOME_VALUE/hub}"
+XDG_CACHE_HOME_VALUE="${OPENPI_XDG_CACHE_HOME:-/mnt/local_storage/.cache}"
+XLA_MEM_FRACTION_VALUE="${OPENPI_XLA_PYTHON_CLIENT_MEM_FRACTION:-0.9}"
+
+export HF_HOME="$HF_HOME_VALUE"
+export HF_HUB_CACHE="$HF_HUB_CACHE_VALUE"
+export XDG_CACHE_HOME="$XDG_CACHE_HOME_VALUE"
+export XLA_PYTHON_CLIENT_MEM_FRACTION="$XLA_MEM_FRACTION_VALUE"
+
+python - <<'PY' "$MANIFEST_JSON" "$RUN_ID" "$TEST_OPENPI_ROOT" "$OPENPI_DIR" "$CONFIG_NAME" "$EXP_NAME" "$MAX_FRAMES" "$NUM_TRAIN_STEPS" "$SAVE_INTERVAL" "$LOG_INTERVAL" "$CHECKPOINT_BASE_DIR" "$ARTIFACTS_ROOT" "$REFRESH_NORM_STATS" "$HF_HOME" "$HF_HUB_CACHE" "$XDG_CACHE_HOME" "$XLA_PYTHON_CLIENT_MEM_FRACTION"
+import json
+import sys
+
+(
+    out_path,
+    run_id,
+    test_openpi_root,
+    openpi_dir,
+    config_name,
+    exp_name,
+    max_frames,
+    num_train_steps,
+    save_interval,
+    log_interval,
+    checkpoint_base_dir,
+    artifacts_root,
+    refresh_norm_stats,
+    hf_home,
+    hf_hub_cache,
+    xdg_cache_home,
+    xla_mem_fraction,
+) = sys.argv[1:]
+
+payload = {
+    "schema_version": 1,
+    "run_id": run_id,
+    "test_openpi_root": test_openpi_root,
+    "openpi_dir": openpi_dir,
+    "config_name": config_name,
+    "exp_name": exp_name,
+    "max_frames": int(max_frames),
+    "num_train_steps": int(num_train_steps),
+    "save_interval": int(save_interval),
+    "log_interval": int(log_interval),
+    "checkpoint_base_dir": checkpoint_base_dir,
+    "artifacts_root": artifacts_root,
+    "refresh_norm_stats": refresh_norm_stats == "1",
+    "env": {
+        "HF_HOME": hf_home,
+        "HF_HUB_CACHE": hf_hub_cache,
+        "XDG_CACHE_HOME": xdg_cache_home,
+        "XLA_PYTHON_CLIENT_MEM_FRACTION": xla_mem_fraction,
+    },
+}
+with open(out_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+print_section() {
+  printf '\n[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1"
+}
+
+run_and_capture() {
+  local log_file="$1"
+  shift
+  (
+    cd "$OPENPI_DIR"
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n'
+    "$@"
+  ) 2>&1 | tee "$log_file"
+}
+
+if (( DRY_RUN )); then
+  print_section "Dry run only"
+  printf 'run_dir=%s\n' "$RUN_DIR"
+  printf 'norm_stats_file=%s\n' "$NORM_STATS_FILE"
+  printf 'checkpoint_run_dir=%s\n' "$CHECKPOINT_RUN_DIR"
+  exit 0
+fi
+
+if (( REFRESH_NORM_STATS )) || [[ ! -f "$NORM_STATS_FILE" ]]; then
+  print_section "Computing bounded norm stats"
+  run_and_capture "$COMPUTE_LOG" uv run scripts/compute_norm_stats.py --config-name "$CONFIG_NAME" --max-frames "$MAX_FRAMES"
+else
+  print_section "Reusing cached norm stats"
+  printf 'Using existing norm stats: %s\n' "$NORM_STATS_FILE" | tee "$COMPUTE_LOG"
+fi
+
+print_section "Launching bounded training"
+run_and_capture "$TRAIN_LOG" uv run scripts/train.py "$CONFIG_NAME" \
+  --exp-name "$EXP_NAME" \
+  --overwrite \
+  --num-train-steps "$NUM_TRAIN_STEPS" \
+  --save-interval "$SAVE_INTERVAL" \
+  --log-interval "$LOG_INTERVAL" \
+  --no-wandb-enabled \
+  --checkpoint-base-dir "$CHECKPOINT_BASE_DIR"
+
+LATEST_CHECKPOINT_DIR="$(find "$CHECKPOINT_RUN_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -n 1 || true)"
+
+python - <<'PY' "$RESULT_JSON" "$NORM_STATS_FILE" "$COMPUTE_LOG" "$TRAIN_LOG" "$CHECKPOINT_RUN_DIR" "$LATEST_CHECKPOINT_DIR"
+import json
+import os
+import sys
+
+result_path, norm_stats_file, compute_log, train_log, checkpoint_run_dir, latest_checkpoint_dir = sys.argv[1:]
+payload = {
+    "schema_version": 1,
+    "norm_stats_file": norm_stats_file,
+    "norm_stats_exists": os.path.exists(norm_stats_file),
+    "compute_log": compute_log,
+    "train_log": train_log,
+    "checkpoint_run_dir": checkpoint_run_dir,
+    "checkpoint_run_dir_exists": os.path.isdir(checkpoint_run_dir),
+    "latest_checkpoint_dir": latest_checkpoint_dir or None,
+}
+with open(result_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+print_section "Completed"
+printf 'Artifacts: %s\n' "$RUN_DIR"
+printf 'Norm stats: %s\n' "$NORM_STATS_FILE"
+printf 'Checkpoint run dir: %s\n' "$CHECKPOINT_RUN_DIR"
+if [[ -n "$LATEST_CHECKPOINT_DIR" ]]; then
+  printf 'Latest checkpoint: %s\n' "$LATEST_CHECKPOINT_DIR"
+fi

--- a/scripts/openpi/run_pi05_libero_finetune_example_pytorch.sh
+++ b/scripts/openpi/run_pi05_libero_finetune_example_pytorch.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run_pi05_libero_finetune_example_pytorch.sh [options]
+
+Runs a bounded PyTorch OpenPI LIBERO fine-tuning example for the documented
+`pi05_libero` config.
+
+Options:
+  --exp-name <name>               Training experiment name.
+  --run-id <id>                   Artifact run id. Defaults to --exp-name.
+  --batch-size <int>              Total batch size. Default: 4
+  --num-train-steps <int>         Number of training steps to run. Default: 1
+  --save-interval <int>           Checkpoint save interval. Default: 1
+  --log-interval <int>            Train log interval. Default: 1
+  --cuda-visible-devices <list>   CUDA_VISIBLE_DEVICES value. Default: 0
+  --jax-checkpoint-dir <path>     JAX checkpoint root to convert.
+                                  Default: /home/ray/.cache/openpi/openpi-assets/checkpoints/pi05_base
+  --converted-weight-dir <path>   Output directory for converted PyTorch weights.
+                                  Default: /mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16
+  --checkpoint-base-dir <path>    Base directory for PyTorch training checkpoints.
+                                  Default: /mnt/local_storage/experiments/openpi_pytorch_checkpoints
+  --artifacts-root <path>         Root directory for logs and manifests.
+                                  Default: test_openpi/tasks/openpi-scripted-libero-finetune-example-pytorch
+  --reconvert-weights             Force reconversion even if model.safetensors already exists.
+  --allow-overwrite               Reuse an existing run artifact directory.
+  --dry-run                       Print the resolved plan and exit.
+  --help                          Show this help.
+USAGE
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_OPENPI_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OPENPI_DIR="$TEST_OPENPI_ROOT/openpi"
+CONFIG_NAME="pi05_libero"
+DEFAULT_EXP_NAME="pi05_libero_pytorch_$(date -u +%Y%m%dT%H%M%SZ)"
+EXP_NAME="$DEFAULT_EXP_NAME"
+RUN_ID=""
+BATCH_SIZE="4"
+NUM_TRAIN_STEPS="1"
+SAVE_INTERVAL="1"
+LOG_INTERVAL="1"
+CUDA_VISIBLE_DEVICES_VALUE="0"
+JAX_CHECKPOINT_DIR="/home/ray/.cache/openpi/openpi-assets/checkpoints/pi05_base"
+CONVERTED_WEIGHT_DIR="/mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16"
+CHECKPOINT_BASE_DIR="/mnt/local_storage/experiments/openpi_pytorch_checkpoints"
+ARTIFACTS_ROOT="$TEST_OPENPI_ROOT/tasks/openpi-scripted-libero-finetune-example-pytorch"
+RECONVERT_WEIGHTS=0
+ALLOW_OVERWRITE=0
+DRY_RUN=0
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --exp-name)
+      EXP_NAME="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --batch-size)
+      BATCH_SIZE="${2:-}"
+      shift 2
+      ;;
+    --num-train-steps)
+      NUM_TRAIN_STEPS="${2:-}"
+      shift 2
+      ;;
+    --save-interval)
+      SAVE_INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --log-interval)
+      LOG_INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --cuda-visible-devices)
+      CUDA_VISIBLE_DEVICES_VALUE="${2:-}"
+      shift 2
+      ;;
+    --jax-checkpoint-dir)
+      JAX_CHECKPOINT_DIR="${2:-}"
+      shift 2
+      ;;
+    --converted-weight-dir)
+      CONVERTED_WEIGHT_DIR="${2:-}"
+      shift 2
+      ;;
+    --checkpoint-base-dir)
+      CHECKPOINT_BASE_DIR="${2:-}"
+      shift 2
+      ;;
+    --artifacts-root)
+      ARTIFACTS_ROOT="${2:-}"
+      shift 2
+      ;;
+    --reconvert-weights)
+      RECONVERT_WEIGHTS=1
+      shift
+      ;;
+    --allow-overwrite)
+      ALLOW_OVERWRITE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$EXP_NAME"
+fi
+
+if [[ ! -d "$OPENPI_DIR" ]]; then
+  echo "OpenPI checkout not found at: $OPENPI_DIR" >&2
+  exit 1
+fi
+
+command -v uv >/dev/null || {
+  echo "uv is required but not installed" >&2
+  exit 1
+}
+
+if ! [[ "$BATCH_SIZE" =~ ^[0-9]+$ && "$NUM_TRAIN_STEPS" =~ ^[0-9]+$ && "$SAVE_INTERVAL" =~ ^[0-9]+$ && "$LOG_INTERVAL" =~ ^[0-9]+$ ]]; then
+  echo "Numeric arguments must be non-negative integers" >&2
+  exit 2
+fi
+
+if (( BATCH_SIZE < 1 || NUM_TRAIN_STEPS < 1 )); then
+  echo "--batch-size and --num-train-steps must be at least 1" >&2
+  exit 2
+fi
+
+RUN_DIR="$ARTIFACTS_ROOT/$RUN_ID"
+PATCH_LOG="$RUN_DIR/patch_transformers.log"
+CONVERT_LOG="$RUN_DIR/convert_checkpoint.log"
+TRAIN_LOG="$RUN_DIR/train_pytorch.log"
+MANIFEST_JSON="$RUN_DIR/run_manifest.json"
+RESULT_JSON="$RUN_DIR/result.json"
+NORM_STATS_FILE="$OPENPI_DIR/assets/pi05_libero/physical-intelligence/libero/norm_stats.json"
+CHECKPOINT_RUN_DIR="$CHECKPOINT_BASE_DIR/$CONFIG_NAME/$EXP_NAME"
+
+if [[ -e "$RUN_DIR" && "$ALLOW_OVERWRITE" -ne 1 ]]; then
+  echo "Run directory already exists: $RUN_DIR (use --allow-overwrite to reuse it)" >&2
+  exit 2
+fi
+
+mkdir -p "$RUN_DIR" "$CHECKPOINT_BASE_DIR"
+
+HF_HOME_VALUE="${OPENPI_HF_HOME:-/mnt/local_storage/huggingface}"
+HF_HUB_CACHE_VALUE="${OPENPI_HF_HUB_CACHE:-$HF_HOME_VALUE/hub}"
+XDG_CACHE_HOME_VALUE="${OPENPI_XDG_CACHE_HOME:-/mnt/local_storage/.cache}"
+PYTORCH_CUDA_ALLOC_CONF_VALUE="${OPENPI_PYTORCH_CUDA_ALLOC_CONF:-max_split_size_mb:128,expandable_segments:True}"
+
+export HF_HOME="$HF_HOME_VALUE"
+export HF_HUB_CACHE="$HF_HUB_CACHE_VALUE"
+export XDG_CACHE_HOME="$XDG_CACHE_HOME_VALUE"
+export PYTORCH_CUDA_ALLOC_CONF="$PYTORCH_CUDA_ALLOC_CONF_VALUE"
+
+python - <<'PY' "$MANIFEST_JSON" "$RUN_ID" "$TEST_OPENPI_ROOT" "$OPENPI_DIR" "$CONFIG_NAME" "$EXP_NAME" "$BATCH_SIZE" "$NUM_TRAIN_STEPS" "$SAVE_INTERVAL" "$LOG_INTERVAL" "$CUDA_VISIBLE_DEVICES_VALUE" "$JAX_CHECKPOINT_DIR" "$CONVERTED_WEIGHT_DIR" "$CHECKPOINT_BASE_DIR" "$ARTIFACTS_ROOT" "$RECONVERT_WEIGHTS" "$HF_HOME" "$HF_HUB_CACHE" "$XDG_CACHE_HOME" "$PYTORCH_CUDA_ALLOC_CONF"
+import json
+import sys
+
+(
+    out_path,
+    run_id,
+    test_openpi_root,
+    openpi_dir,
+    config_name,
+    exp_name,
+    batch_size,
+    num_train_steps,
+    save_interval,
+    log_interval,
+    cuda_visible_devices,
+    jax_checkpoint_dir,
+    converted_weight_dir,
+    checkpoint_base_dir,
+    artifacts_root,
+    reconvert_weights,
+    hf_home,
+    hf_hub_cache,
+    xdg_cache_home,
+    pytorch_cuda_alloc_conf,
+) = sys.argv[1:]
+
+payload = {
+    "schema_version": 1,
+    "run_id": run_id,
+    "test_openpi_root": test_openpi_root,
+    "openpi_dir": openpi_dir,
+    "config_name": config_name,
+    "exp_name": exp_name,
+    "batch_size": int(batch_size),
+    "num_train_steps": int(num_train_steps),
+    "save_interval": int(save_interval),
+    "log_interval": int(log_interval),
+    "cuda_visible_devices": cuda_visible_devices,
+    "jax_checkpoint_dir": jax_checkpoint_dir,
+    "converted_weight_dir": converted_weight_dir,
+    "checkpoint_base_dir": checkpoint_base_dir,
+    "artifacts_root": artifacts_root,
+    "reconvert_weights": reconvert_weights == "1",
+    "env": {
+        "HF_HOME": hf_home,
+        "HF_HUB_CACHE": hf_hub_cache,
+        "XDG_CACHE_HOME": xdg_cache_home,
+        "PYTORCH_CUDA_ALLOC_CONF": pytorch_cuda_alloc_conf,
+    },
+}
+with open(out_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+print_section() {
+  printf '\n[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1"
+}
+
+run_in_openpi() {
+  local log_file="$1"
+  shift
+  (
+    cd "$OPENPI_DIR"
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n'
+    "$@"
+  ) 2>&1 | tee "$log_file"
+}
+
+ensure_patched_transformers() {
+  local site_pkg="$OPENPI_DIR/.venv/lib/python3.11/site-packages/transformers"
+  local installed_file="$site_pkg/models/paligemma/modeling_paligemma.py"
+  local replacement_root="$OPENPI_DIR/src/openpi/models_pytorch/transformers_replace"
+  local replacement_file="$replacement_root/models/paligemma/modeling_paligemma.py"
+
+  if [[ -f "$installed_file" ]] && cmp -s "$replacement_file" "$installed_file" && [[ "$(stat -c '%h' "$installed_file")" == "1" ]]; then
+    printf 'Transformers patch already applied in local .venv\n' | tee "$PATCH_LOG"
+    return
+  fi
+
+  run_in_openpi "$PATCH_LOG" uv sync --reinstall-package transformers --link-mode copy
+  (
+    cd "$OPENPI_DIR"
+    printf '$ cp -r ./src/openpi/models_pytorch/transformers_replace/* .venv/lib/python3.11/site-packages/transformers/\n' | tee -a "$PATCH_LOG"
+    cp -r ./src/openpi/models_pytorch/transformers_replace/* .venv/lib/python3.11/site-packages/transformers/
+  ) >>"$PATCH_LOG" 2>&1
+}
+
+ensure_converted_weights() {
+  if [[ -f "$CONVERTED_WEIGHT_DIR/model.safetensors" && "$RECONVERT_WEIGHTS" -ne 1 ]]; then
+    printf 'Using existing converted PyTorch checkpoint: %s\n' "$CONVERTED_WEIGHT_DIR" | tee "$CONVERT_LOG"
+    return
+  fi
+
+  mkdir -p "$CONVERTED_WEIGHT_DIR"
+  run_in_openpi "$CONVERT_LOG" uv run examples/convert_jax_model_to_pytorch.py \
+    --checkpoint-dir "$JAX_CHECKPOINT_DIR" \
+    --config-name "$CONFIG_NAME" \
+    --output-path "$CONVERTED_WEIGHT_DIR" \
+    --precision bfloat16
+}
+
+if (( DRY_RUN )); then
+  print_section "Dry run only"
+  printf 'run_dir=%s\n' "$RUN_DIR"
+  printf 'converted_weight_dir=%s\n' "$CONVERTED_WEIGHT_DIR"
+  printf 'checkpoint_run_dir=%s\n' "$CHECKPOINT_RUN_DIR"
+  exit 0
+fi
+
+print_section "Preparing local PyTorch environment"
+ensure_patched_transformers
+
+print_section "Ensuring converted PyTorch weights"
+ensure_converted_weights
+
+print_section "Launching bounded PyTorch training"
+(
+  cd "$OPENPI_DIR"
+  printf '$'
+  printf ' %q' env \
+    CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES_VALUE" \
+    HF_HOME="$HF_HOME" \
+    HF_HUB_CACHE="$HF_HUB_CACHE" \
+    XDG_CACHE_HOME="$XDG_CACHE_HOME" \
+    PYTORCH_CUDA_ALLOC_CONF="$PYTORCH_CUDA_ALLOC_CONF" \
+    uv run scripts/train_pytorch.py "$CONFIG_NAME" \
+    --exp-name "$EXP_NAME" \
+    --pytorch-weight-path "$CONVERTED_WEIGHT_DIR" \
+    --batch-size "$BATCH_SIZE" \
+    --num-train-steps "$NUM_TRAIN_STEPS" \
+    --save-interval "$SAVE_INTERVAL" \
+    --log-interval "$LOG_INTERVAL" \
+    --checkpoint-base-dir "$CHECKPOINT_BASE_DIR" \
+    --no-wandb-enabled \
+    --overwrite
+  printf '\n'
+  env \
+    CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES_VALUE" \
+    HF_HOME="$HF_HOME" \
+    HF_HUB_CACHE="$HF_HUB_CACHE" \
+    XDG_CACHE_HOME="$XDG_CACHE_HOME" \
+    PYTORCH_CUDA_ALLOC_CONF="$PYTORCH_CUDA_ALLOC_CONF" \
+    uv run scripts/train_pytorch.py "$CONFIG_NAME" \
+      --exp-name "$EXP_NAME" \
+      --pytorch-weight-path "$CONVERTED_WEIGHT_DIR" \
+      --batch-size "$BATCH_SIZE" \
+      --num-train-steps "$NUM_TRAIN_STEPS" \
+      --save-interval "$SAVE_INTERVAL" \
+      --log-interval "$LOG_INTERVAL" \
+      --checkpoint-base-dir "$CHECKPOINT_BASE_DIR" \
+      --no-wandb-enabled \
+      --overwrite
+) 2>&1 | tee "$TRAIN_LOG"
+
+LATEST_CHECKPOINT_DIR="$(find "$CHECKPOINT_RUN_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -n 1 || true)"
+
+python - <<'PY' "$RESULT_JSON" "$NORM_STATS_FILE" "$PATCH_LOG" "$CONVERT_LOG" "$TRAIN_LOG" "$CONVERTED_WEIGHT_DIR" "$CHECKPOINT_RUN_DIR" "$LATEST_CHECKPOINT_DIR"
+import json
+import os
+import sys
+
+(
+    result_path,
+    norm_stats_file,
+    patch_log,
+    convert_log,
+    train_log,
+    converted_weight_dir,
+    checkpoint_run_dir,
+    latest_checkpoint_dir,
+) = sys.argv[1:]
+
+payload = {
+    "schema_version": 1,
+    "norm_stats_file": norm_stats_file,
+    "norm_stats_exists": os.path.exists(norm_stats_file),
+    "patch_log": patch_log,
+    "convert_log": convert_log,
+    "train_log": train_log,
+    "converted_weight_dir": converted_weight_dir,
+    "converted_weight_exists": os.path.exists(os.path.join(converted_weight_dir, "model.safetensors")),
+    "checkpoint_run_dir": checkpoint_run_dir,
+    "checkpoint_run_dir_exists": os.path.isdir(checkpoint_run_dir),
+    "latest_checkpoint_dir": latest_checkpoint_dir or None,
+}
+with open(result_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+print_section "Completed"
+printf 'Artifacts: %s\n' "$RUN_DIR"
+printf 'Converted weights: %s\n' "$CONVERTED_WEIGHT_DIR"
+printf 'Checkpoint run dir: %s\n' "$CHECKPOINT_RUN_DIR"
+if [[ -n "$LATEST_CHECKPOINT_DIR" ]]; then
+  printf 'Latest checkpoint: %s\n' "$LATEST_CHECKPOINT_DIR"
+fi

--- a/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/convert_checkpoint.log
+++ b/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/convert_checkpoint.log
@@ -1,0 +1,1 @@
+Using existing converted PyTorch checkpoint: /mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16

--- a/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/patch_transformers.log
+++ b/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/patch_transformers.log
@@ -1,0 +1,1 @@
+Transformers patch already applied in local .venv

--- a/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/result.json
+++ b/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/result.json
@@ -1,0 +1,13 @@
+{
+  "checkpoint_run_dir": "/mnt/local_storage/experiments/openpi_pytorch_checkpoints/pi05_libero/scripted_pytorch_smoke_fixed_20260307T011319Z",
+  "checkpoint_run_dir_exists": true,
+  "convert_log": "/home/ray/default/vla/test_openpi/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/convert_checkpoint.log",
+  "converted_weight_dir": "/mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16",
+  "converted_weight_exists": true,
+  "latest_checkpoint_dir": "/mnt/local_storage/experiments/openpi_pytorch_checkpoints/pi05_libero/scripted_pytorch_smoke_fixed_20260307T011319Z/1",
+  "norm_stats_exists": true,
+  "norm_stats_file": "/home/ray/default/vla/test_openpi/openpi/assets/pi05_libero/physical-intelligence/libero/norm_stats.json",
+  "patch_log": "/home/ray/default/vla/test_openpi/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/patch_transformers.log",
+  "schema_version": 1,
+  "train_log": "/home/ray/default/vla/test_openpi/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/train_pytorch.log"
+}

--- a/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/run_manifest.json
+++ b/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/run_manifest.json
@@ -1,0 +1,24 @@
+{
+  "artifacts_root": "/home/ray/default/vla/test_openpi/tasks/openpi-scripted-libero-finetune-example-pytorch",
+  "batch_size": 4,
+  "checkpoint_base_dir": "/mnt/local_storage/experiments/openpi_pytorch_checkpoints",
+  "config_name": "pi05_libero",
+  "converted_weight_dir": "/mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16",
+  "cuda_visible_devices": "0",
+  "env": {
+    "HF_HOME": "/mnt/local_storage/huggingface",
+    "HF_HUB_CACHE": "/mnt/local_storage/huggingface/hub",
+    "PYTORCH_CUDA_ALLOC_CONF": "max_split_size_mb:128,expandable_segments:True",
+    "XDG_CACHE_HOME": "/mnt/local_storage/.cache"
+  },
+  "exp_name": "scripted_pytorch_smoke_fixed_20260307T011319Z",
+  "jax_checkpoint_dir": "/home/ray/.cache/openpi/openpi-assets/checkpoints/pi05_base",
+  "log_interval": 1,
+  "num_train_steps": 1,
+  "openpi_dir": "/home/ray/default/vla/test_openpi/openpi",
+  "reconvert_weights": false,
+  "run_id": "scripted_pytorch_smoke_fixed_20260307T011319Z",
+  "save_interval": 1,
+  "schema_version": 1,
+  "test_openpi_root": "/home/ray/default/vla/test_openpi"
+}

--- a/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/train_pytorch.log
+++ b/tasks/openpi-scripted-libero-finetune-example-pytorch/scripted_pytorch_smoke_fixed_20260307T011319Z/train_pytorch.log
@@ -1,0 +1,57 @@
+$ env CUDA_VISIBLE_DEVICES=0 HF_HOME=/mnt/local_storage/huggingface HF_HUB_CACHE=/mnt/local_storage/huggingface/hub XDG_CACHE_HOME=/mnt/local_storage/.cache PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:128\,expandable_segments:True uv run scripts/train_pytorch.py pi05_libero --exp-name scripted_pytorch_smoke_fixed_20260307T011319Z --pytorch-weight-path /mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16 --batch-size 4 --num-train-steps 1 --save-interval 1 --log-interval 1 --checkpoint-base-dir /mnt/local_storage/experiments/openpi_pytorch_checkpoints --no-wandb-enabled --overwrite
+warning: The `tool.uv.dev-dependencies` field (used in `packages/openpi-client/pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
+17:13:30.157 [I] Created experiment checkpoint directory: /mnt/local_storage/experiments/openpi_pytorch_checkpoints/pi05_libero/scripted_pytorch_smoke_fixed_20260307T011319Z (3973460:train_pytorch.py:340)
+17:13:30.171 [I] Using batch size per GPU: 4 (total batch size across 1 GPUs: 4)                  (3973460:train_pytorch.py:354)
+17:13:30.245 [I] Loaded norm stats from /home/ray/default/vla/test_openpi/openpi/assets/pi05_libero/physical-intelligence/libero (3973460:config.py:196)
+17:13:30.246 [I] data_config: DataConfig(repo_id='physical-intelligence/libero', asset_id='physical-intelligence/libero', norm_stats={'state': NormStats(mean=array([-0.04492831,  0.03360355,  0.75745153,  2.97318912, -0.20376144,
+       -0.12366653,  0.02715557, -0.02741778]), std=array([0.10426783, 0.15130948, 0.38158861, 0.34558034, 0.90297723,
+       0.32642943, 0.0140612 , 0.0139208 ]), q01=array([-3.95318311e-01, -2.67847098e-01,  2.61877041e-02,  1.52094365e+00,
+       -2.69408816e+00, -1.06879084e+00,  1.70741546e-03, -4.00321179e-02]), q99=array([ 1.39933273e-01,  3.29854794e-01,  1.26990345e+00,  3.27965328e+00,
+        2.42308025e+00,  6.08078202e-01,  4.03201519e-02, -1.75895424e-03])), 'actions': NormStats(mean=array([ 0.05749531,  0.08408882, -0.08509924,  0.00123146,  0.00639978,
+       -0.00656478, -0.0590332 ]), std=array([0.32838118, 0.3787801 , 0.44534925, 0.03938985, 0.06377058,
+       0.07561158, 0.99825603]), q01=array([-0.694125  , -0.811875  , -0.9375    , -0.10507414, -0.15987771,
+       -0.22285821, -1.        ]), q99=array([0.937125  , 0.86775   , 0.937125  , 0.13497064, 0.19700315,
+       0.32245072, 1.        ]))}, repack_transforms=Group(inputs=[RepackTransform(structure={'observation/image': 'image', 'observation/wrist_image': 'wrist_image', 'observation/state': 'state', 'actions': 'actions', 'prompt': 'prompt'})], outputs=()), data_transforms=Group(inputs=[LiberoInputs(model_type=<ModelType.PI05: 'pi05'>)], outputs=[LiberoOutputs()]), model_transforms=Group(inputs=[InjectDefaultPrompt(prompt=None), ResizeImages(height=224, width=224), TokenizePrompt(tokenizer=<openpi.models.tokenizer.PaligemmaTokenizer object at 0x7e9085516e10>, discrete_state_input=False), PadStatesAndActions(model_action_dim=32)], outputs=()), use_quantile_norm=True, action_sequence_keys=('actions',), prompt_from_task=True, rlds_data_dir=None, action_space=None, datasets=()) (3973460:data_loader.py:243)
+17:13:30.247 [W] 
+The dataset you requested (physical-intelligence/libero) is in 2.0 format.
+While current version of LeRobot is backward-compatible with it, the version of your dataset still uses global
+stats instead of per-episode stats. Update your dataset stats to the new format using this command:
+```
+python lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py --repo-id=physical-intelligence/libero
+```
+
+If you encounter a problem, contact LeRobot maintainers on [Discord](https://discord.com/invite/s3KuuzsPFb)
+or open an [issue on GitHub](https://github.com/huggingface/lerobot/issues/new/choose).
+ (3973460:utils.py:303)
+17:13:30.252 [W] 
+The dataset you requested (physical-intelligence/libero) is in 2.0 format.
+While current version of LeRobot is backward-compatible with it, the version of your dataset still uses global
+stats instead of per-episode stats. Update your dataset stats to the new format using this command:
+```
+python lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py --repo-id=physical-intelligence/libero
+```
+
+If you encounter a problem, contact LeRobot maintainers on [Discord](https://discord.com/invite/s3KuuzsPFb)
+or open an [issue on GitHub](https://github.com/huggingface/lerobot/issues/new/choose).
+ (3973460:utils.py:303)
+17:13:34.679 [I] local_batch_size: 4                                                              (3973460:data_loader.py:324)
+INFO:2026-03-06 17:13:34,994:jax._src.xla_bridge:925: Unable to initialize backend 'rocm': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
+17:13:34.994 [I] Unable to initialize backend 'rocm': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig' (3973460:xla_bridge.py:925)
+INFO:2026-03-06 17:13:34,994:jax._src.xla_bridge:925: Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
+17:13:34.994 [I] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory (3973460:xla_bridge.py:925)
+17:14:22.389 [I] Enabled gradient checkpointing for PI0Pytorch model                              (3973460:pi0_pytorch.py:133)
+17:14:22.389 [I] Enabled gradient checkpointing for memory optimization                           (3973460:train_pytorch.py:414)
+17:14:22.389 [I] Step 0 (after_model_creation): GPU memory - allocated: 7.47GB, reserved: 7.48GB, free: 0.01GB, peak_allocated: 7.47GB, peak_reserved: 7.48GB (3973460:train_pytorch.py:304)
+17:14:22.389 [I] Loading weights from: /mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16 (3973460:train_pytorch.py:443)
+17:14:23.526 [I] Loaded PyTorch weights from /mnt/local_storage/experiments/openpi_pytorch/pi05_base_for_libero_bfloat16 (3973460:train_pytorch.py:449)
+17:14:23.530 [I] Running on: ip-10-0-128-51 | world_size=1                                        (3973460:train_pytorch.py:486)
+17:14:23.530 [I] Training config: batch_size=4, effective_batch_size=4, num_train_steps=1         (3973460:train_pytorch.py:489)
+17:14:23.530 [I] Memory optimizations: gradient_checkpointing=True                                (3973460:train_pytorch.py:492)
+17:14:23.531 [I] LR schedule: warmup=10000, peak_lr=5.00e-05, decay_steps=1000000, end_lr=5.00e-05 (3973460:train_pytorch.py:493)
+17:14:23.531 [I] Optimizer: AdamW, weight_decay=1e-10, clip_norm=1.0                              (3973460:train_pytorch.py:496)
+17:14:23.531 [I] EMA is not supported for PyTorch training                                        (3973460:train_pytorch.py:499)
+17:14:23.531 [I] Training precision: bfloat16                                                     (3973460:train_pytorch.py:500)
+Training:   0%|          | 0/1 [00:00<?, ?it/s]17:14:38.599 [I] Step 0 (after_backward): GPU memory - allocated: 14.28GB, reserved: 40.51GB, free: 26.23GB, peak_allocated: 15.39GB, peak_reserved: 40.51GB (3973460:train_pytorch.py:304)
+17:14:38.876 [I] step=0 loss=0.0780 lr=5.00e-09 grad_norm=0.90 time=15.3s                         (3973460:train_pytorch.py:582)
+17:15:12.934 [I] Saved checkpoint at step 1 -> /mnt/local_storage/experiments/openpi_pytorch_checkpoints/pi05_libero/scripted_pytorch_smoke_fixed_20260307T011319Z/1 (3973460:train_pytorch.py:190)
+Training: 100%|██████████| 1/1 [00:49<00:00, 49.40s/it]Training: 100%|██████████| 1/1 [00:49<00:00, 49.40s/it, loss=0.0780, lr=5.00e-09, step=1]Training: 100%|██████████| 1/1 [00:49<00:00, 49.41s/it, loss=0.0780, lr=5.00e-09, step=1]


### PR DESCRIPTION
## Summary
- add bounded JAX and PyTorch wrapper scripts for the `pi05_libero` fine-tune flow
- document the local scripted entrypoints and artifact locations
- commit a successful scripted PyTorch smoke-run log/manifest bundle

## Verification
- `bash -n scripts/openpi/run_pi05_libero_finetune_example.sh`
- `bash -n scripts/openpi/run_pi05_libero_finetune_example_pytorch.sh`
- `scripts/openpi/run_pi05_libero_finetune_example_pytorch.sh --exp-name scripted_pytorch_smoke_fixed_20260307T011319Z --run-id scripted_pytorch_smoke_fixed_20260307T011319Z`
